### PR TITLE
Add index to generated HTML notice file (v1.1.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.8] - 2025-09-15
+
+### Added
+- Table of Contents index for HTML notice files with navigation links
+- Package-based anchor IDs for direct navigation to specific packages
+- License information displayed next to each package in the index
+- Smooth scrolling CSS for better navigation experience
+- "Back to Top" link for easy return to the index
+
+### Changed
+- HTML template now lists all packages individually in the Table of Contents
+- Anchor IDs are placed on package elements rather than license headers
+- Improved support for package names with special characters (colons, slashes)
+
 ## [1.1.7] - 2025-09-10
 
 ### Fixed

--- a/purl2notices.cache.json
+++ b/purl2notices.cache.json
@@ -1,10 +1,10 @@
 {
   "bomFormat": "CycloneDX",
   "specVersion": "1.6",
-  "serialNumber": "urn:uuid:b5a10d31-263f-4b0c-a112-3c6084ae8427",
+  "serialNumber": "urn:uuid:ef6bb792-f78d-4fed-81b1-3d143a8eb521",
   "version": 1,
   "metadata": {
-    "timestamp": "2025-09-16T06:42:51.260334+00:00",
+    "timestamp": "2025-09-16T06:47:06.258118+00:00",
     "tools": [
       {
         "vendor": "oscarvalenzuelab",
@@ -22,7 +22,7 @@
   "components": [
     {
       "type": "library",
-      "bom-ref": "6678e3c6-bd7a-4f06-98c9-f2c4599305ff",
+      "bom-ref": "3ac74405-9204-4d6a-90a9-b1fc1c2ac74e",
       "name": "express",
       "version": "4.18.0",
       "purl": "pkg:npm/express@4.18.0",
@@ -67,7 +67,7 @@
     },
     {
       "type": "library",
-      "bom-ref": "0a22e8c4-eafb-4e6f-bddd-35f5018704a1",
+      "bom-ref": "5d6c0628-c82b-4e8a-bd31-faf06dc8b4f8",
       "name": "lodash",
       "version": "4.17.21",
       "purl": "pkg:npm/lodash@4.17.21",
@@ -109,7 +109,7 @@
     },
     {
       "type": "library",
-      "bom-ref": "fbe559e6-a520-4fe4-8941-871823c39fe4",
+      "bom-ref": "c7e766c8-fae0-420c-9d8f-a12491a0911d",
       "name": "requests",
       "version": "2.28.0",
       "purl": "pkg:pypi/requests@2.28.0",

--- a/purl2notices.cache.json
+++ b/purl2notices.cache.json
@@ -1,0 +1,179 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:b5a10d31-263f-4b0c-a112-3c6084ae8427",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-09-16T06:42:51.260334+00:00",
+    "tools": [
+      {
+        "vendor": "oscarvalenzuelab",
+        "name": "purl2notices",
+        "version": "0.1.0"
+      }
+    ],
+    "properties": [
+      {
+        "name": "purl2notices:cache_version",
+        "value": "1.0"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "6678e3c6-bd7a-4f06-98c9-f2c4599305ff",
+      "name": "express",
+      "version": "4.18.0",
+      "purl": "pkg:npm/express@4.18.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "copyright",
+          "value": "Copyright 2009-2013 TJ Holowaychuk; Copyright 2013 Roman Shtylman; Copyright 2014-2015 Douglas Christopher Wilson; Copyright TJ Holowaychuk; Copyright Aaron Heckmann; Copyright Ciaran Jessup; Copyright Douglas Christopher Wilson; Copyright Guillermo Rauch; Copyright Jonathan Ong"
+        },
+        {
+          "name": "copyright",
+          "value": "Copyright 2009-2013 TJ Holowaychuk"
+        },
+        {
+          "name": "copyright",
+          "value": "Copyright 2013 Roman Shtylman"
+        },
+        {
+          "name": "copyright",
+          "value": "Copyright 2014-2015 Douglas Christopher Wilson"
+        },
+        {
+          "name": "purl2notices:status",
+          "value": "success"
+        },
+        {
+          "name": "purl2notices:license_text:MIT",
+          "value": "MIT License\n\nCopyright (c) <year> <copyright holders>\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and\nassociated documentation files (the \"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial\nportions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT\nLIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO\nEVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER\nIN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "0a22e8c4-eafb-4e6f-bddd-35f5018704a1",
+      "name": "lodash",
+      "version": "4.17.21",
+      "purl": "pkg:npm/lodash@4.17.21",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "CC0-1.0"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "copyright",
+          "value": "Copyright Jeremy Ashkenas"
+        },
+        {
+          "name": "purl2notices:status",
+          "value": "success"
+        },
+        {
+          "name": "purl2notices:license_text:MIT",
+          "value": "MIT License\n\nCopyright (c) <year> <copyright holders>\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and\nassociated documentation files (the \"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial\nportions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT\nLIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO\nEVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER\nIN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n"
+        },
+        {
+          "name": "purl2notices:license_text:CC0-1.0",
+          "value": "Creative Commons Legal Code\n\nCC0 1.0 Universal\n\n    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE\n    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN\n    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS\n    INFORMATION ON AN \"AS-IS\" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES\n    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS\n    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM\n    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED\n    HEREUNDER.\n\nStatement of Purpose\n\nThe laws of most jurisdictions throughout the world automatically confer\nexclusive Copyright and Related Rights (defined below) upon the creator\nand subsequent owner(s) (each and all, an \"owner\") of an original work of\nauthorship and/or a database (each, a \"Work\").\n\nCertain owners wish to permanently relinquish those rights to a Work for\nthe purpose of contributing to a commons of creative, cultural and\nscientific works (\"Commons\") that the public can reliably and without fear\nof later claims of infringement build upon, modify, incorporate in other\nworks, reuse and redistribute as freely as possible in any form whatsoever\nand for any purposes, including without limitation commercial purposes.\nThese owners may contribute to the Commons to promote the ideal of a free\nculture and the further production of creative, cultural and scientific\nworks, or to gain reputation or greater distribution for their Work in\npart through the use and efforts of others.\n\nFor these and/or other purposes and motivations, and without any\nexpectation of additional consideration or compensation, the person\nassociating CC0 with a Work (the \"Affirmer\"), to the extent that he or she\nis an owner of Copyright and Related Rights in the Work, voluntarily\nelects to apply CC0 to the Work and publicly distribute the Work under its\nterms, with knowledge of his or her Copyright and Related Rights in the\nWork and the meaning and intended legal effect of CC0 on those rights.\n\n1. Copyright and Related Rights. A Work made available under CC0 may be\nprotected by copyright and related or neighboring rights (\"Copyright and\nRelated Rights\"). Copyright and Related Rights include, but are not\nlimited to, the following:\n\n  i. the right to reproduce, adapt, distribute, perform, display,\n     communicate, and translate a Work;\n ii. moral rights retained by the original author(s) and/or performer(s);\niii. publicity and privacy rights pertaining to a person's image or\n     likeness depicted in a Work;\n iv. rights protecting against unfair competition in regards to a Work,\n     subject to the limitations in paragraph 4(a), below;\n  v. rights protecting the extraction, dissemination, use and reuse of data\n     in a Work;\n vi. database rights (such as those arising under Directive 96/9/EC of the\n     European Parliament and of the Council of 11 March 1996 on the legal\n     protection of databases, and under any national implementation\n     thereof, including any amended or successor version of such\n     directive); and\nvii. other similar, equivalent or corresponding rights throughout the\n     world based on applicable law or treaty, and any national\n     implementations thereof.\n\n2. Waiver. To the greatest extent permitted by, but not in contravention\nof, applicable law, Affirmer hereby overtly, fully, permanently,\nirrevocably and unconditionally waives, abandons, and surrenders all of\nAffirmer's Copyright and Related Rights and associated claims and causes\nof action, whether now known or unknown (including existing as well as\nfuture claims and causes of action), in the Work (i) in all territories\nworldwide, (ii) for the maximum duration provided by applicable law or\ntreaty (including future time extensions), (iii) in any current or future\nmedium and for any number of copies, and (iv) for any purpose whatsoever,\nincluding without limitation commercial, advertising or promotional\npurposes (the \"Waiver\"). Affirmer makes the Waiver for the benefit of each\nmember of the public at large and to the detriment of Affirmer's heirs and\nsuccessors, fully intending that such Waiver shall not be subject to\nrevocation, rescission, cancellation, termination, or any other legal or\nequitable action to disrupt the quiet enjoyment of the Work by the public\nas contemplated by Affirmer's express Statement of Purpose.\n\n3. Public License Fallback. Should any part of the Waiver for any reason\nbe judged legally invalid or ineffective under applicable law, then the\nWaiver shall be preserved to the maximum extent permitted taking into\naccount Affirmer's express Statement of Purpose. In addition, to the\nextent the Waiver is so judged Affirmer hereby grants to each affected\nperson a royalty-free, non transferable, non sublicensable, non exclusive,\nirrevocable and unconditional license to exercise Affirmer's Copyright and\nRelated Rights in the Work (i) in all territories worldwide, (ii) for the\nmaximum duration provided by applicable law or treaty (including future\ntime extensions), (iii) in any current or future medium and for any number\nof copies, and (iv) for any purpose whatsoever, including without\nlimitation commercial, advertising or promotional purposes (the\n\"License\"). The License shall be deemed effective as of the date CC0 was\napplied by Affirmer to the Work. Should any part of the License for any\nreason be judged legally invalid or ineffective under applicable law, such\npartial invalidity or ineffectiveness shall not invalidate the remainder\nof the License, and in such case Affirmer hereby affirms that he or she\nwill not (i) exercise any of his or her remaining Copyright and Related\nRights in the Work or (ii) assert any associated claims and causes of\naction with respect to the Work, in either case contrary to Affirmer's\nexpress Statement of Purpose.\n\n4. Limitations and Disclaimers.\n\n a. No trademark or patent rights held by Affirmer are waived, abandoned,\n    surrendered, licensed or otherwise affected by this document.\n b. Affirmer offers the Work as-is and makes no representations or\n    warranties of any kind concerning the Work, express, implied,\n    statutory or otherwise, including without limitation warranties of\n    title, merchantability, fitness for a particular purpose, non\n    infringement, or the absence of latent or other defects, accuracy, or\n    the present or absence of errors, whether or not discoverable, all to\n    the greatest extent permissible under applicable law.\n c. Affirmer disclaims responsibility for clearing rights of other persons\n    that may apply to the Work or any use thereof, including without\n    limitation any person's Copyright and Related Rights in the Work.\n    Further, Affirmer disclaims responsibility for obtaining any necessary\n    consents, permissions or other rights required for any use of the\n    Work.\n d. Affirmer understands and acknowledges that Creative Commons is not a\n    party to this document and has no duty or obligation with respect to\n    this CC0 or use of the Work.\n"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "fbe559e6-a520-4fe4-8941-871823c39fe4",
+      "name": "requests",
+      "version": "2.28.0",
+      "purl": "pkg:pypi/requests@2.28.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache"
+          }
+        },
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        },
+        {
+          "license": {
+            "id": "MIT"
+          }
+        },
+        {
+          "license": {
+            "id": "Pixar"
+          }
+        }
+      ],
+      "properties": [
+        {
+          "name": "copyright",
+          "value": "Copyright 2017 Kenneth Reitz; Copyright 2022 Kenneth Reitz\"; Copyright 2012 Kenneth Reitz"
+        },
+        {
+          "name": "copyright",
+          "value": "Copyright 2017 Kenneth Reitz"
+        },
+        {
+          "name": "copyright",
+          "value": "Copyright 2022 Kenneth Reitz\""
+        },
+        {
+          "name": "copyright",
+          "value": "Copyright 2012 Kenneth Reitz"
+        },
+        {
+          "name": "purl2notices:status",
+          "value": "success"
+        },
+        {
+          "name": "purl2notices:license_text:Apache-2.0",
+          "value": "Apache License\nVersion 2.0, January 2004\nhttp://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n\"License\" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.\n\n\"Licensor\" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.\n\n\"Legal Entity\" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, \"control\" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.\n\n\"You\" (or \"Your\") shall mean an individual or Legal Entity exercising permissions granted by this License.\n\n\"Source\" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.\n\n\"Object\" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.\n\n\"Work\" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).\n\n\"Derivative Works\" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.\n\n\"Contribution\" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, \"submitted\" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as \"Not a Contribution.\"\n\n\"Contributor\" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:\n\n     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and\n\n     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and\n\n     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and\n\n     (d) If the Work includes a \"NOTICE\" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.\n\n     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\nTo apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets \"[]\" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same \"printed page\" as the copyright notice for easier identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\nhttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n"
+        },
+        {
+          "name": "purl2notices:license_text:MIT",
+          "value": "MIT License\n\nCopyright (c) <year> <copyright holders>\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and\nassociated documentation files (the \"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial\nportions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT\nLIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO\nEVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER\nIN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n"
+        },
+        {
+          "name": "purl2notices:license_text:Pixar",
+          "value": "\n                               Modified Apache 2.0 License\n\n\n   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n   1. Definitions.\n\n      \"License\" shall mean the terms and conditions for use, reproduction,\n      and distribution as defined by Sections 1 through 9 of this document.\n\n      \"Licensor\" shall mean the copyright owner or entity authorized by\n      the copyright owner that is granting the License.\n\n      \"Legal Entity\" shall mean the union of the acting entity and all\n      other entities that control, are controlled by, or are under common\n      control with that entity. For the purposes of this definition,\n      \"control\" means (i) the power, direct or indirect, to cause the\n      direction or management of such entity, whether by contract or\n      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n      outstanding shares, or (iii) beneficial ownership of such entity.\n\n      \"You\" (or \"Your\") shall mean an individual or Legal Entity\n      exercising permissions granted by this License.\n\n      \"Source\" form shall mean the preferred form for making modifications,\n      including but not limited to software source code, documentation\n      source, and configuration files.\n\n      \"Object\" form shall mean any form resulting from mechanical\n      transformation or translation of a Source form, including but\n      not limited to compiled object code, generated documentation,\n      and conversions to other media types.\n\n      \"Work\" shall mean the work of authorship, whether in Source or\n      Object form, made available under the License, as indicated by a\n      copyright notice that is included in or attached to the work\n      (an example is provided in the Appendix below).\n\n      \"Derivative Works\" shall mean any work, whether in Source or Object\n      form, that is based on (or derived from) the Work and for which the\n      editorial revisions, annotations, elaborations, or other modifications\n      represent, as a whole, an original work of authorship. For the purposes\n      of this License, Derivative Works shall not include works that remain\n      separable from, or merely link (or bind by name) to the interfaces of,\n      the Work and Derivative Works thereof.\n\n      \"Contribution\" shall mean any work of authorship, including\n      the original version of the Work and any modifications or additions\n      to that Work or Derivative Works thereof, that is intentionally\n      submitted to Licensor for inclusion in the Work by the copyright owner\n      or by an individual or Legal Entity authorized to submit on behalf of\n      the copyright owner. For the purposes of this definition, \"submitted\"\n      means any form of electronic, verbal, or written communication sent\n      to the Licensor or its representatives, including but not limited to\n      communication on electronic mailing lists, source code control systems,\n      and issue tracking systems that are managed by, or on behalf of, the\n      Licensor for the purpose of discussing and improving the Work, but\n      excluding communication that is conspicuously marked or otherwise\n      designated in writing by the copyright owner as \"Not a Contribution.\"\n\n      \"Contributor\" shall mean Licensor and any individual or Legal Entity\n      on behalf of whom a Contribution has been received by Licensor and\n      subsequently incorporated within the Work.\n\n   2. Grant of Copyright License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      copyright license to reproduce, prepare Derivative Works of,\n      publicly display, publicly perform, sublicense, and distribute the\n      Work and such Derivative Works in Source or Object form.\n\n   3. Grant of Patent License. Subject to the terms and conditions of\n      this License, each Contributor hereby grants to You a perpetual,\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n      (except as stated in this section) patent license to make, have made,\n      use, offer to sell, sell, import, and otherwise transfer the Work,\n      where such license applies only to those patent claims licensable\n      by such Contributor that are necessarily infringed by their\n      Contribution(s) alone or by combination of their Contribution(s)\n      with the Work to which such Contribution(s) was submitted. If You\n      institute patent litigation against any entity (including a\n      cross-claim or counterclaim in a lawsuit) alleging that the Work\n      or a Contribution incorporated within the Work constitutes direct\n      or contributory patent infringement, then any patent licenses\n      granted to You under this License for that Work shall terminate\n      as of the date such litigation is filed.\n\n   4. Redistribution. You may reproduce and distribute copies of the\n      Work or Derivative Works thereof in any medium, with or without\n      modifications, and in Source or Object form, provided that You\n      meet the following conditions:\n\n      (a) You must give any other recipients of the Work or\n          Derivative Works a copy of this License; and\n\n      (b) You must cause any modified files to carry prominent notices\n          stating that You changed the files; and\n\n      (c) You must retain, in the Source form of any Derivative Works\n          that You distribute, all copyright, patent, trademark, and\n          attribution notices from the Source form of the Work,\n          excluding those notices that do not pertain to any part of\n          the Derivative Works; and\n\n      (d) If the Work includes a \"NOTICE\" text file as part of its\n          distribution, then any Derivative Works that You distribute must\n          include a readable copy of the attribution notices contained\n          within such NOTICE file, excluding those notices that do not\n          pertain to any part of the Derivative Works, in at least one\n          of the following places: within a NOTICE text file distributed\n          as part of the Derivative Works; within the Source form or\n          documentation, if provided along with the Derivative Works; or,\n          within a display generated by the Derivative Works, if and\n          wherever such third-party notices normally appear. The contents\n          of the NOTICE file are for informational purposes only and\n          do not modify the License. You may add Your own attribution\n          notices within Derivative Works that You distribute, alongside\n          or as an addendum to the NOTICE text from the Work, provided\n          that such additional attribution notices cannot be construed\n          as modifying the License.\n\n      You may add Your own copyright statement to Your modifications and\n      may provide additional or different license terms and conditions\n      for use, reproduction, or distribution of Your modifications, or\n      for any such Derivative Works as a whole, provided Your use,\n      reproduction, and distribution of the Work otherwise complies with\n      the conditions stated in this License.\n\n   5. Submission of Contributions. Unless You explicitly state otherwise,\n      any Contribution intentionally submitted for inclusion in the Work\n      by You to the Licensor shall be under the terms and conditions of\n      this License, without any additional terms or conditions.\n      Notwithstanding the above, nothing herein shall supersede or modify\n      the terms of any separate license agreement you may have executed\n      with Licensor regarding such Contributions.\n\n   6. Trademarks. This License does not grant permission to use the trade\n      names, trademarks, service marks, or product names of the Licensor\n      and its affiliates, except as required to comply with Section 4(c) of\n      the License and to reproduce the content of the NOTICE file.\n\n   7. Disclaimer of Warranty. Unless required by applicable law or\n      agreed to in writing, Licensor provides the Work (and each\n      Contributor provides its Contributions) on an \"AS IS\" BASIS,\n      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n      implied, including, without limitation, any warranties or conditions\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n      PARTICULAR PURPOSE. You are solely responsible for determining the\n      appropriateness of using or redistributing the Work and assume any\n      risks associated with Your exercise of permissions under this License.\n\n   8. Limitation of Liability. In no event and under no legal theory,\n      whether in tort (including negligence), contract, or otherwise,\n      unless required by applicable law (such as deliberate and grossly\n      negligent acts) or agreed to in writing, shall any Contributor be\n      liable to You for damages, including any direct, indirect, special,\n      incidental, or consequential damages of any character arising as a\n      result of this License or out of the use or inability to use the\n      Work (including but not limited to damages for loss of goodwill,\n      work stoppage, computer failure or malfunction, or any and all\n      other commercial damages or losses), even if such Contributor\n      has been advised of the possibility of such damages.\n\n   9. Accepting Warranty or Additional Liability. While redistributing\n      the Work or Derivative Works thereof, You may choose to offer,\n      and charge a fee for, acceptance of support, warranty, indemnity,\n      or other liability obligations and/or rights consistent with this\n      License. However, in accepting such obligations, You may act only\n      on Your own behalf and on Your sole responsibility, not on behalf\n      of any other Contributor, and only if You agree to indemnify,\n      defend, and hold each Contributor harmless for any liability\n      incurred by, or claims asserted against, such Contributor by reason\n      of your accepting any such warranty or additional liability.\n\n"
+        }
+      ]
+    }
+  ]
+}

--- a/purl2notices/__init__.py
+++ b/purl2notices/__init__.py
@@ -1,6 +1,6 @@
 """purl2notices - Generate legal notices for software packages."""
 
-__version__ = "1.1.7"
+__version__ = "1.1.8"
 __author__ = "Oscar Valenzuela B"
 __email__ = "oscar.valenzuela.b@gmail.com"
 

--- a/purl2notices/templates/default.html.j2
+++ b/purl2notices/templates/default.html.j2
@@ -67,15 +67,47 @@
         .no-license {
             background: #e74c3c;
         }
+        html {
+            scroll-behavior: smooth;
+        }
     </style>
 </head>
 <body>
     <h1>Legal Notices</h1>
     <p>This product includes software developed by third parties. The following notices apply to the included packages:</p>
 
+    <!-- Table of Contents -->
+    <div style="background: white; padding: 20px; border-radius: 5px; margin: 20px 0; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
+        <h2 style="color: #2c3e50; margin-top: 0;">Table of Contents</h2>
+        {% if group_by_license %}
+        <ul style="list-style: none; padding-left: 0;">
+            {% for license_id, package_group in packages_by_license.items() %}
+            <li style="margin: 10px 0;">
+                <a href="#license-{{ license_id | replace(' ', '-') | replace(',', '') | replace('(', '') | replace(')', '') | lower }}"
+                   style="text-decoration: none; color: #3498db; font-weight: 500;">
+                    {{ license_id }}
+                    <span style="color: #7f8c8d; font-weight: normal;">({{ package_group | length }} package{{ 's' if package_group | length > 1 else '' }})</span>
+                </a>
+            </li>
+            {% endfor %}
+        </ul>
+        {% else %}
+        <ul style="list-style: none; padding-left: 0;">
+            {% for package in packages %}
+            <li style="margin: 8px 0;">
+                <a href="#package-{{ package.name | replace(' ', '-') | replace('@', '') | replace('/', '-') | lower }}-{{ package.version | replace('.', '-') }}"
+                   style="text-decoration: none; color: #3498db;">
+                    {{ package.display_name }}
+                </a>
+            </li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    </div>
+
     {% if group_by_license %}
     {% for license_id, package_group in packages_by_license.items() %}
-    <h2>
+    <h2 id="license-{{ license_id | replace(' ', '-') | replace(',', '') | replace('(', '') | replace(')', '') | lower }}">
         <span class="license-badge{% if license_id == 'NOASSERTION' %} no-license{% endif %}">{{ license_id }}</span>
     </h2>
     
@@ -105,7 +137,7 @@
     
     {% else %}
     {% for package in packages %}
-    <h2>{{ package.display_name }}</h2>
+    <h2 id="package-{{ package.name | replace(' ', '-') | replace('@', '') | replace('/', '-') | lower }}-{{ package.version | replace('.', '-') }}">{{ package.display_name }}</h2>
     
     <div class="package-list">
         <strong>License:</strong>
@@ -135,6 +167,11 @@
     {% endif %}
     {% endfor %}
     {% endif %}
+
+    <!-- Back to top link -->
+    <div style="text-align: center; margin: 40px 0;">
+        <a href="#" style="color: #3498db; text-decoration: none;">↑ Back to Top</a>
+    </div>
 
     <hr style="margin-top: 50px; border: 1px solid #bdc3c7;">
     <p style="text-align: center; color: #7f8c8d; font-size: 0.9em;">

--- a/purl2notices/templates/default.html.j2
+++ b/purl2notices/templates/default.html.j2
@@ -79,42 +79,45 @@
     <!-- Table of Contents -->
     <div style="background: white; padding: 20px; border-radius: 5px; margin: 20px 0; box-shadow: 0 2px 4px rgba(0,0,0,0.1);">
         <h2 style="color: #2c3e50; margin-top: 0;">Table of Contents</h2>
-        {% if group_by_license %}
         <ul style="list-style: none; padding-left: 0;">
+            {% if group_by_license %}
             {% for license_id, package_group in packages_by_license.items() %}
-            <li style="margin: 10px 0;">
-                <a href="#license-{{ license_id | replace(' ', '-') | replace(',', '') | replace('(', '') | replace(')', '') | lower }}"
-                   style="text-decoration: none; color: #3498db; font-weight: 500;">
-                    {{ license_id }}
-                    <span style="color: #7f8c8d; font-weight: normal;">({{ package_group | length }} package{{ 's' if package_group | length > 1 else '' }})</span>
-                </a>
-            </li>
-            {% endfor %}
-        </ul>
-        {% else %}
-        <ul style="list-style: none; padding-left: 0;">
-            {% for package in packages %}
+            {% for package in package_group %}
             <li style="margin: 8px 0;">
-                <a href="#package-{{ package.name | replace(' ', '-') | replace('@', '') | replace('/', '-') | lower }}-{{ package.version | replace('.', '-') }}"
+                <a href="#package-{{ package.name | replace(' ', '-') | replace('@', '') | replace('/', '-') | replace(':', '-') | lower }}-{{ package.version | replace('.', '-') | replace(':', '-') }}"
                    style="text-decoration: none; color: #3498db;">
                     {{ package.display_name }}
+                    <span style="color: #7f8c8d; font-size: 0.9em;">({{ license_id }})</span>
                 </a>
             </li>
             {% endfor %}
+            {% endfor %}
+            {% else %}
+            {% for package in packages %}
+            <li style="margin: 8px 0;">
+                <a href="#package-{{ package.name | replace(' ', '-') | replace('@', '') | replace('/', '-') | replace(':', '-') | lower }}-{{ package.version | replace('.', '-') | replace(':', '-') }}"
+                   style="text-decoration: none; color: #3498db;">
+                    {{ package.display_name }}
+                    {% if package.licenses %}
+                    <span style="color: #7f8c8d; font-size: 0.9em;">({{ package.licenses | map(attribute='spdx_id') | join(', ') }})</span>
+                    {% endif %}
+                </a>
+            </li>
+            {% endfor %}
+            {% endif %}
         </ul>
-        {% endif %}
     </div>
 
     {% if group_by_license %}
     {% for license_id, package_group in packages_by_license.items() %}
-    <h2 id="license-{{ license_id | replace(' ', '-') | replace(',', '') | replace('(', '') | replace(')', '') | lower }}">
+    <h2>
         <span class="license-badge{% if license_id == 'NOASSERTION' %} no-license{% endif %}">{{ license_id }}</span>
     </h2>
-    
+
     <div class="package-list">
         <h3>Packages:</h3>
         {% for package in package_group %}
-        <div class="package-item">{{ package.display_name }}</div>
+        <div class="package-item" id="package-{{ package.name | replace(' ', '-') | replace('@', '') | replace('/', '-') | replace(':', '-') | lower }}-{{ package.version | replace('.', '-') | replace(':', '-') }}">{{ package.display_name }}</div>
         {% endfor %}
     </div>
 
@@ -137,7 +140,7 @@
     
     {% else %}
     {% for package in packages %}
-    <h2 id="package-{{ package.name | replace(' ', '-') | replace('@', '') | replace('/', '-') | lower }}-{{ package.version | replace('.', '-') }}">{{ package.display_name }}</h2>
+    <h2 id="package-{{ package.name | replace(' ', '-') | replace('@', '') | replace('/', '-') | replace(':', '-') | lower }}-{{ package.version | replace('.', '-') | replace(':', '-') }}">{{ package.display_name }}</h2>
     
     <div class="package-list">
         <strong>License:</strong>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "semantic-copycat-purl2notices"
-version = "1.1.7"
+version = "1.1.8"
 description = "Generate legal notices (attribution to authors and copyrights) for software packages"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary
- Implements Table of Contents index for HTML notice files as requested in #6
- Adds package-based navigation with direct links to each package
- Bumps version to 1.1.8

## Changes
- Added Table of Contents section after the main title in HTML output
- Created anchor IDs for each individual package (not grouped by license)
- Each package link in the index shows its associated license(s) in parentheses
- Added smooth scrolling CSS for better user experience
- Included "Back to Top" link for easy navigation
- Updated to handle special characters in package names (colons, slashes)

## Test Plan
- [x] Generated HTML output with test packages
- [x] Verified Table of Contents displays all packages
- [x] Tested navigation links jump to correct package sections
- [x] Confirmed both grouped-by-license and ungrouped modes work
- [x] Validated special characters in package names are handled correctly

Closes #6