### PR TITLE
Fix homepage property access in formatter (closes #8)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -253,8 +253,8 @@ Total Packages: {{ total_packages }}
   {%- if package.source_path %}
   - Source: {{ package.source_path }}
   {%- endif %}
-  {%- if package.homepage %}
-  - Homepage: {{ package.homepage }}
+  {%- if package.metadata and package.metadata.homepage %}
+  - Homepage: {{ package.metadata.homepage }}
   {%- endif %}
 {% endfor %}
 

--- a/purl2notices/formatter.py
+++ b/purl2notices/formatter.py
@@ -210,7 +210,7 @@ class NoticeFormatter:
                             "name": pkg.name,
                             "version": pkg.version,
                             "purl": pkg.purl,
-                            "homepage": pkg.homepage,
+                            "homepage": pkg.metadata.get("homepage") if pkg.metadata else None,
                             "source_path": pkg.source_path
                         }
                         for pkg in pkgs
@@ -235,7 +235,7 @@ class NoticeFormatter:
                     "version": pkg.version,
                     "purl": pkg.purl,
                     "licenses": [lic.id for lic in pkg.licenses],
-                    "homepage": pkg.homepage,
+                    "homepage": pkg.metadata.get("homepage") if pkg.metadata else None,
                     "source_path": pkg.source_path
                 }
                 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,10 @@ def sample_package() -> Package:
         purl="pkg:npm/test-package@1.0.0",
         licenses=[License(spdx_id="MIT", name="MIT License", text="MIT License text...")],
         copyrights=[Copyright(statement="Copyright (c) 2024 Test Author")],
-        homepage="https://example.com",
-        description="Test package description"
+        metadata={
+            "homepage": "https://example.com",
+            "description": "Test package description"
+        }
     )
 
 


### PR DESCRIPTION
## Summary
- Fixed formatter.py attempting to access non-existent `Package.homepage` property
- Homepage data is correctly stored in Package's metadata dictionary
- Updated all references to access homepage from metadata

## Changes
1. **purl2notices/formatter.py** - Changed `pkg.homepage` to `pkg.metadata.get("homepage")`
2. **tests/conftest.py** - Moved homepage from direct parameter to metadata dictionary
3. **docs/configuration.md** - Updated template example to use `package.metadata.homepage`

## Test Plan
- [x] Verified Package model doesn't have homepage property
- [x] Confirmed homepage is extracted into metadata dictionary by upmex_extractor
- [x] Updated test fixtures to properly store homepage in metadata
- [x] Fixed formatter to safely access homepage from metadata

Fixes #8